### PR TITLE
Fix brew service start command

### DIFF
--- a/setup_Mac.sh
+++ b/setup_Mac.sh
@@ -8,7 +8,7 @@ git clone https://github.com/nccgroup/autochrome.git &
 ruby autochrome/autochrome.rb
 open ~/Applications/Chromium.app &
 git clone https://github.com/sethlaw/vtm.git 
-brew services mysql start
+brew services start mysql
 mysqladmin -u root create vtmdb
 cd vtm
 pip3.7 install -r requirements.txt


### PR DESCRIPTION
From brew's documentation for `brew services command`:

```
[ sudo ] brew services start formula|--all
Start the service formula immediately and register it to launch at login (or boot).
```